### PR TITLE
Add basic http authorization for all GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The exporter can be configured with commandline arguments, environment variables
 |Flag|ENV variable|Default|Meaning|
 |---|---|---|---|
 |--eventstore-url|EVENTSTORE_URL|http://localhost:2113|Eventstore HTTP endpoint|
+|--eventstore-user|EVENTSTORE_USER|admin|Eventstore user|
+|--eventstore-password|EVENTSTORE_PASSWORD|changeit|Eventstore password|
 |--cluster-mode|CLUSTER_MODE|cluster|Set to 'single' when monitoring a single node instance, set to 'cluster' when monitoring a cluster. This settings decides whether gossip stats endpoint is queired.|
 |--port|PORT|9448|Port to expose scrape endpoint on|
 |--timeout|TIMEOUT|10s|Timeout when calling EventStore|

--- a/eventstore_client.go
+++ b/eventstore_client.go
@@ -81,7 +81,10 @@ func get(path string) <-chan getResult {
 	go func() {
 		log.WithField("url", url).Debug("GET request to EventStore")
 
-		response, err := client.Get(url)
+		client := &http.Client{}
+		req, err := http.NewRequest("GET", url, nil)
+		req.SetBasicAuth(eventStoreUser, eventStorePassword)
+		response, err := client.Do(req)
 		if err != nil {
 			result <- getResult{nil, err}
 			return

--- a/eventstore_client.go
+++ b/eventstore_client.go
@@ -81,7 +81,6 @@ func get(path string) <-chan getResult {
 	go func() {
 		log.WithField("url", url).Debug("GET request to EventStore")
 
-		client := &http.Client{}
 		req, err := http.NewRequest("GET", url, nil)
 		req.SetBasicAuth(eventStoreUser, eventStorePassword)
 		response, err := client.Do(req)

--- a/eventstore_exporter.go
+++ b/eventstore_exporter.go
@@ -20,8 +20,10 @@ var (
 	port    uint
 	verbose bool
 
-	eventStoreURL  	string
-	clusterMode		string
+	eventStoreURL      string
+	eventStoreUser     string
+	eventStorePassword string
+	clusterMode        string
 )
 
 func serveLandingPage() {
@@ -47,6 +49,8 @@ func serveMetrics() {
 
 func readAndValidateConfig() {
 	flag.StringVar(&eventStoreURL, "eventstore-url", "http://localhost:2113", "EventStore URL")
+	flag.StringVar(&eventStoreUser, "eventstore-user", "admin", "EventStore User")
+	flag.StringVar(&eventStorePassword, "eventstore-password", "changeit", "EventStore Password")
 	flag.UintVar(&port, "port", 9448, "Port to expose scraping endpoint on")
 	flag.DurationVar(&timeout, "timeout", time.Second*10, "Timeout when calling EventStore")
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
@@ -60,6 +64,7 @@ func readAndValidateConfig() {
 
 	log.WithFields(logrus.Fields{
 		"eventStoreURL": eventStoreURL,
+		"eventStoreUser": eventStoreUser,
 		"port":       	port,
 		"timeout":    	timeout,
 		"verbose":    	verbose,


### PR DESCRIPTION
First of all thanks for the work you are doing with that project, we are using it and is great!

The problem I've found it was after upgrading to eventstore 5.0.2 version, the subscriptions endpoint is protected with basic http authentication and we aren't getting the metrics.

Here you have the release notes from eventstore:
https://eventstore.org/blog/20190723/event-store-5.0.2-release/

I did a test of the PR in our system and looks ok.

Thanks! 