### PR TITLE
Specify a JSON Accept header on stats scrapes

### DIFF
--- a/eventstore_client.go
+++ b/eventstore_client.go
@@ -97,6 +97,7 @@ func get(path string, acceptNotFound bool) <-chan getResult {
 		if eventStoreUser != "" && eventStorePassword != "" {
 			req.SetBasicAuth(eventStoreUser, eventStorePassword)
 		}
+		req.Header.Add("Accept", "application/json")
 		response, err := client.Do(req)
 		if err != nil {
 			result <- getResult{nil, err}


### PR DESCRIPTION
At least on my ES install (5.0.5, debian 9), the `/stats` endpoint fails with a serialization header unless I specify a JSON Accept header. Once I made this change this exporter began working successfully on my installation.