### PR TITLE
added parked messages metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ eventstore_subscription_last_processed_event_number{event_stream_id="test-stream
 # HELP eventstore_subscription_messages_in_flight Number of messages in flight for subscription
 # TYPE eventstore_subscription_messages_in_flight gauge
 eventstore_subscription_messages_in_flight{event_stream_id="test-stream",group_name="group1"} 0
+# HELP eventstore_subscription_oldest_parked_message_age_seconds Oldest parked message age for subscription in seconds
+# TYPE eventstore_subscription_oldest_parked_message_age_seconds gauge
+eventstore_subscription_oldest_parked_message_age_seconds{event_stream_id="test-stream",group_name="group1"} 33
+# HELP eventstore_subscription_parked_messages Number of parked messages for subscription
+# TYPE eventstore_subscription_parked_messages gauge
+eventstore_subscription_parked_messages{event_stream_id="test-stream",group_name="group1"} 1
 # HELP eventstore_tcp_connections Current number of TCP connections
 # TYPE eventstore_tcp_connections gauge
 eventstore_tcp_connections 1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ go build -o eventstore_exporter
     --eventstore-user=admin \
     --eventstore-password=changeit \
     --cluster-mode=single \
-    --insecure-skip-verify
+    --insecure-skip-verify \
+    --enable-parked-messages-stats
 ```
 
 ### Using Docker
@@ -44,6 +45,7 @@ The exporter can be configured with commandline arguments, environment variables
 |--timeout|TIMEOUT|10s|Timeout when calling EventStore|
 |--verbose|VERBOSE|false|Enable verbose logging|
 |--insecure-skip-verify|INSECURE_SKIP_VERIFY|false|Skip TLS certificatte verification for EventStore HTTP client|
+|--enable-parked-messages-stats|ENABLE_PARKED_MESSAGES_STATS|false|Enable parked messages stats scraping|
 
 ## Grafana dashboard
 

--- a/collector.go
+++ b/collector.go
@@ -311,11 +311,11 @@ func collectParkedMessagesPerSubscriptionMetric(stats *stats, desc *prometheus.D
 		metadataResult := <-metadataResultChan
 		tbValue, _ := jp.GetInt(metadataResult.result, "$tb")
 		log.Info("$tb Value: " + fmt.Sprint(tbValue))
-		totalNumberOfParkedMessages := float64(lastEventNumber - tbValue)
+		totalNumberOfParkedMessages := lastEventNumber - tbValue
 		log.Info("Total number of parked messages:" + fmt.Sprint(totalNumberOfParkedMessages))
 
 		// get oldest message in the queue
-		getOldestMessageURL := fmt.Sprintf("/streams/$persistentsubscription-%s::%s-parked/%s/forward/1", eventStreamID, groupName, fmt.Sprint(lastEventNumber-int64(totalNumberOfParkedMessages)))
+		getOldestMessageURL := fmt.Sprintf("/streams/$persistentsubscription-%s::%s-parked/%s/forward/1", eventStreamID, groupName, fmt.Sprint(lastEventNumber-totalNumberOfParkedMessages))
 		getOldestMessageResultChan := get(getOldestMessageURL, false)
 		getOldestMessageResult := <-getOldestMessageResultChan
 		oldestMessageUpdatedDate := ""
@@ -325,7 +325,7 @@ func collectParkedMessagesPerSubscriptionMetric(stats *stats, desc *prometheus.D
 		log.Info("Oldest Message Date: " + oldestMessageUpdatedDate)
 
 		// add metric
-		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, totalNumberOfParkedMessages, eventStreamID, groupName, oldestMessageUpdatedDate)
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(totalNumberOfParkedMessages), eventStreamID, groupName, oldestMessageUpdatedDate)
 	})
 }
 

--- a/collector.go
+++ b/collector.go
@@ -89,7 +89,7 @@ func NewCollector() *Collector {
 		subscriptionConnectionCount:             prometheus.NewDesc("eventstore_subscription_connections", "Number of connections to subscription", []string{"event_stream_id", "group_name"}, nil),
 		subscriptionTotalInFlightMessages:       prometheus.NewDesc("eventstore_subscription_messages_in_flight", "Number of messages in flight for subscription", []string{"event_stream_id", "group_name"}, nil),
 		subscriptionTotalNumberOfParkedMessages: prometheus.NewDesc("eventstore_subscription_parked_messages", "Number of parked messages for subscription", []string{"event_stream_id", "group_name"}, nil),
-		subscriptionOldestParkedMessage:         prometheus.NewDesc("eventstore_subscription_parked_messages_oldest_message", "Oldest parked message in subscription", []string{"event_stream_id", "group_name"}, nil),
+		subscriptionOldestParkedMessage:         prometheus.NewDesc("eventstore_subscription_oldest_parked_message_age_seconds", "Oldest parked message age for subscription in seconds", []string{"event_stream_id", "group_name"}, nil),
 	}
 }
 
@@ -134,6 +134,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.subscriptionConnectionCount
 	ch <- c.subscriptionTotalInFlightMessages
 	ch <- c.subscriptionTotalNumberOfParkedMessages
+	ch <- c.subscriptionOldestParkedMessage
 }
 
 // Collect function

--- a/collector.go
+++ b/collector.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
-	"github.com/buger/jsonparser"
 	jp "github.com/buger/jsonparser"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -49,6 +46,7 @@ type Collector struct {
 	subscriptionConnectionCount             *prometheus.Desc
 	subscriptionTotalInFlightMessages       *prometheus.Desc
 	subscriptionTotalNumberOfParkedMessages *prometheus.Desc
+	subscriptionOldestParkedMessage         *prometheus.Desc
 }
 
 // NewCollector function
@@ -90,7 +88,8 @@ func NewCollector() *Collector {
 		subscriptionLastKnownEventNumber:        prometheus.NewDesc("eventstore_subscription_last_known_event_number", "Last known event number in subscription", []string{"event_stream_id", "group_name"}, nil),
 		subscriptionConnectionCount:             prometheus.NewDesc("eventstore_subscription_connections", "Number of connections to subscription", []string{"event_stream_id", "group_name"}, nil),
 		subscriptionTotalInFlightMessages:       prometheus.NewDesc("eventstore_subscription_messages_in_flight", "Number of messages in flight for subscription", []string{"event_stream_id", "group_name"}, nil),
-		subscriptionTotalNumberOfParkedMessages: prometheus.NewDesc("eventstore_subscription_parked_messages", "Number of parked messages for subscription", []string{"event_stream_id", "group_name", "oldest_message"}, nil),
+		subscriptionTotalNumberOfParkedMessages: prometheus.NewDesc("eventstore_subscription_parked_messages", "Number of parked messages for subscription", []string{"event_stream_id", "group_name"}, nil),
+		subscriptionOldestParkedMessage:         prometheus.NewDesc("eventstore_subscription_parked_messages_oldest_message", "Oldest parked message in subscription", []string{"event_stream_id", "group_name"}, nil),
 	}
 }
 
@@ -181,7 +180,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		collectPerSubscriptionMetric(stats, c.subscriptionLastKnownEventNumber, getSubscriptionLastKnownEventNumber, ch)
 		collectPerSubscriptionMetric(stats, c.subscriptionLastProcessedEventNumber, getSubscriptionLastProcessedEventNumber, ch)
 		collectPerSubscriptionMetric(stats, c.subscriptionTotalInFlightMessages, getSubscriptionTotalInFlightMessages, ch)
-		collectParkedMessagesPerSubscriptionMetric(stats, c.subscriptionTotalNumberOfParkedMessages, ch)
+		collectParkedMessagesPerSubscriptionMetric(stats.parkedMessagesStats, c.subscriptionTotalNumberOfParkedMessages, ch)
+		collectOldestParkedMessagePerSubscriptionMetric(stats.parkedMessagesStats, c.subscriptionOldestParkedMessage, ch)
 
 		if isInClusterMode() {
 			collectPerMemberMetric(stats, c.clusterMemberAlive, getMemberIsAlive, ch)
@@ -288,45 +288,16 @@ func collectPerSubscriptionMetric(stats *stats, desc *prometheus.Desc, collectFu
 	})
 }
 
-func collectParkedMessagesPerSubscriptionMetric(stats *stats, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
-	jp.ArrayEach(stats.subscriptionsStats, func(jsonValue []byte, dataType jp.ValueType, offset int, err error) {
-		eventStreamID, _ := jp.GetString(jsonValue, "eventStreamId")
-		groupName, _ := jp.GetString(jsonValue, "groupName")
+func collectParkedMessagesPerSubscriptionMetric(stats []parkedMessagesStats, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
+	for _, stat := range stats {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, stat.totalNumberOfParkedMessages, stat.eventStreamID, stat.groupName)
+	}
+}
 
-		// get parked messages max event number
-		parkedMessagesURL := fmt.Sprintf("/streams/$persistentsubscription-%s::%s-parked/head/backward/1", eventStreamID, groupName)
-		log.Info(parkedMessagesURL)
-		parkedMessagesResult := get(parkedMessagesURL, false)
-		eTagString, _ := jp.GetString((<-parkedMessagesResult).result, "eTag")
-		lastEventNumber, lastEventNumberErr := strconv.ParseInt(strings.Split(eTagString, ";")[0], 10, 64)
-		if lastEventNumberErr == nil {
-			lastEventNumber++ // +1 because Ids start from 0
-			log.Info(lastEventNumber)
-		}
-
-		// get $tb (truncate before) value from metadata
-		metadataURL := fmt.Sprintf("/streams/$persistentsubscription-%s::%s-parked/metadata", eventStreamID, groupName)
-		log.Info(metadataURL)
-		metadataResultChan := get(metadataURL, false)
-		metadataResult := <-metadataResultChan
-		tbValue, _ := jp.GetInt(metadataResult.result, "$tb")
-		log.Info("$tb Value: " + fmt.Sprint(tbValue))
-		totalNumberOfParkedMessages := lastEventNumber - tbValue
-		log.Info("Total number of parked messages:" + fmt.Sprint(totalNumberOfParkedMessages))
-
-		// get oldest message in the queue
-		getOldestMessageURL := fmt.Sprintf("/streams/$persistentsubscription-%s::%s-parked/%s/forward/1", eventStreamID, groupName, fmt.Sprint(lastEventNumber-totalNumberOfParkedMessages))
-		getOldestMessageResultChan := get(getOldestMessageURL, false)
-		getOldestMessageResult := <-getOldestMessageResultChan
-		oldestMessageUpdatedDate := ""
-		jsonparser.ArrayEach(getOldestMessageResult.result, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
-			oldestMessageUpdatedDate, _ = jp.GetString(value, "updated")
-		}, "entries")
-		log.Info("Oldest Message Date: " + oldestMessageUpdatedDate)
-
-		// add metric
-		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(totalNumberOfParkedMessages), eventStreamID, groupName, oldestMessageUpdatedDate)
-	})
+func collectOldestParkedMessagePerSubscriptionMetric(stats []parkedMessagesStats, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
+	for _, stat := range stats {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, stat.oldestParkedMessageAgeInSeconds, stat.eventStreamID, stat.groupName)
+	}
 }
 
 func getSubscriptionTotalItemsProcessed(subscription []byte) (prometheus.ValueType, float64) {

--- a/eventstore_client.go
+++ b/eventstore_client.go
@@ -141,16 +141,14 @@ func getSubscriptionParkedMessagesStats(subscriptions []byte) (*[]parkedMessages
 		totalNumberOfParkedMessages := lastEventNumber - truncateBeforeValue
 
 		var oldestParkedMessage float64
-		if true {
-			oldestMessageID := lastEventNumber - totalNumberOfParkedMessages
-			oldestParkedMessage, err = getOldestParkedMessageTimeInSeconds(eventStreamID, groupName, oldestMessageID)
-			if err != nil {
-				log.WithFields(logrus.Fields{
-					"eventStreamId": eventStreamID,
-					"groupName":     groupName,
-					"error":         err,
-				}).Warn("Error while getting oldest parked message.")
-			}
+		oldestMessageID := lastEventNumber - totalNumberOfParkedMessages
+		oldestParkedMessage, err = getOldestParkedMessageTimeInSeconds(eventStreamID, groupName, oldestMessageID)
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"eventStreamId": eventStreamID,
+				"groupName":     groupName,
+				"error":         err,
+			}).Warn("Error while getting oldest parked message.")
 		}
 
 		result = append(result, parkedMessagesStats{

--- a/eventstore_client.go
+++ b/eventstore_client.go
@@ -5,6 +5,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/buger/jsonparser"
+	jp "github.com/buger/jsonparser"
 )
 
 var (
@@ -33,11 +41,19 @@ type getResult struct {
 }
 
 type stats struct {
-	serverStats        []byte
-	gossipStats        []byte
-	projectionStats    []byte
-	info               []byte
-	subscriptionsStats []byte
+	serverStats         []byte
+	gossipStats         []byte
+	projectionStats     []byte
+	info                []byte
+	subscriptionsStats  []byte
+	parkedMessagesStats []parkedMessagesStats
+}
+
+type parkedMessagesStats struct {
+	eventStreamID                   string
+	groupName                       string
+	totalNumberOfParkedMessages     float64
+	oldestParkedMessageAgeInSeconds float64
 }
 
 func getStats() (*stats, error) {
@@ -76,13 +92,139 @@ func getStats() (*stats, error) {
 		}
 	}
 
+	var parkedMessagesStatsResult []parkedMessagesStats
+	if enableParkedMessagesStats {
+		parkedMessagesStats, err := getSubscriptionParkedMessagesStats(subscriptionsStatsResult.result)
+		if err != nil {
+			log.WithError(err).Error("Error while getting parked messages for subscriptions.")
+		} else {
+			parkedMessagesStatsResult = *parkedMessagesStats
+		}
+	}
+
 	return &stats{
 		serverStatsResult.result,
 		gossipStatsResult.result,
 		projectionStatsResult.result,
 		infoResult.result,
 		subscriptionsStatsResult.result,
+		parkedMessagesStatsResult,
 	}, nil
+}
+
+func getSubscriptionParkedMessagesStats(subscriptions []byte) (*[]parkedMessagesStats, error) {
+	var result []parkedMessagesStats
+	jp.ArrayEach(subscriptions, func(jsonValue []byte, dataType jp.ValueType, offset int, err error) {
+		eventStreamID, _ := jp.GetString(jsonValue, "eventStreamId")
+		groupName, _ := jp.GetString(jsonValue, "groupName")
+
+		lastEventNumber, err := getParkedMessagesLastEventNumber(eventStreamID, groupName)
+
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"eventStreamId": eventStreamID,
+				"groupName":     groupName,
+				"err":           err,
+			}).Warn("Error while getting parked messages last event number.")
+		}
+
+		truncateBeforeValue, err := getParkedMessagesTruncateBeforeValue(eventStreamID, groupName, lastEventNumber)
+
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"eventStreamId": eventStreamID,
+				"groupName":     groupName,
+				"error":         err,
+			}).Warn("Error while getting parked messages truncate before value.")
+		}
+
+		totalNumberOfParkedMessages := lastEventNumber - truncateBeforeValue
+
+		var oldestParkedMessage float64
+		if true {
+			oldestMessageID := lastEventNumber - totalNumberOfParkedMessages
+			oldestParkedMessage, err = getOldestParkedMessageTimeInSeconds(eventStreamID, groupName, oldestMessageID)
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					"eventStreamId": eventStreamID,
+					"groupName":     groupName,
+					"error":         err,
+				}).Warn("Error while getting oldest parked message.")
+			}
+		}
+
+		result = append(result, parkedMessagesStats{
+			eventStreamID:                   eventStreamID,
+			groupName:                       groupName,
+			totalNumberOfParkedMessages:     float64(totalNumberOfParkedMessages),
+			oldestParkedMessageAgeInSeconds: oldestParkedMessage})
+	})
+	return &result, nil
+}
+
+func getOldestParkedMessageTimeInSeconds(eventStreamID string, groupName string, oldestMessageID int64) (float64, error) {
+	getOldestMessageURL := fmt.Sprintf("/streams/$persistentsubscription-%s::%s-parked/%s/forward/1", eventStreamID, groupName, strconv.FormatInt(oldestMessageID, 10))
+	getOldestMessageResultChan := get(getOldestMessageURL, false)
+	getOldestMessageResult := <-getOldestMessageResultChan
+	if getOldestMessageResult.err != nil {
+		return 0, getOldestMessageResult.err
+	}
+	oldestMessageUpdatedDateResult := ""
+	jsonparser.ArrayEach(getOldestMessageResult.result, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		oldestMessageUpdatedDateResult, _ = jp.GetString(value, "updated")
+	}, "entries")
+
+	loc, _ := time.LoadLocation("UTC")
+	timeNow := time.Now().In(loc)
+	oldestMessageUpdatedDate, err := time.Parse(time.RFC3339Nano, oldestMessageUpdatedDateResult)
+
+	if err != nil {
+		return 0, err
+	}
+
+	timeInSeconds := float64(timeNow.Sub(oldestMessageUpdatedDate) / time.Second)
+
+	return timeInSeconds, nil
+}
+
+func getParkedMessagesLastEventNumber(eventStreamID string, groupName string) (int64, error) {
+	parkedMessagesURL := fmt.Sprintf("/streams/$persistentsubscription-%s::%s-parked/head/backward/1", eventStreamID, groupName)
+	parkedMessagesResultChan := get(parkedMessagesURL, false)
+	parkedMessagesResult := <-parkedMessagesResultChan
+
+	if parkedMessagesResult.err != nil {
+		return 0, parkedMessagesResult.err
+	}
+
+	eTagString, _ := jp.GetString(parkedMessagesResult.result, "eTag")
+
+	lastEventNumber, err := strconv.ParseInt(strings.Split(eTagString, ";")[0], 10, 64)
+
+	if err != nil {
+		return 0, err
+	}
+
+	lastEventNumber++ // +1 because Ids start from 0
+
+	return lastEventNumber, nil
+}
+
+func getParkedMessagesTruncateBeforeValue(eventStreamID string, groupName string, lastEventNumber int64) (int64, error) {
+	metadataURL := fmt.Sprintf("/streams/$persistentsubscription-%s::%s-parked/metadata", eventStreamID, groupName)
+	metadataResultChan := get(metadataURL, false)
+	metadataResult := <-metadataResultChan
+
+	if metadataResult.err != nil {
+		return 0, metadataResult.err
+	}
+
+	truncateBeforeValue, err := jp.GetInt(metadataResult.result, "$tb")
+
+	if err != nil {
+		return 0, err
+	}
+
+	return truncateBeforeValue, nil
 }
 
 func get(path string, acceptNotFound bool) <-chan getResult {

--- a/eventstore_exporter.go
+++ b/eventstore_exporter.go
@@ -21,10 +21,11 @@ var (
 	verbose            bool
 	insecureSkipVerify bool
 
-	eventStoreURL      string
-	eventStoreUser     string
-	eventStorePassword string
-	clusterMode        string
+	eventStoreURL             string
+	eventStoreUser            string
+	eventStorePassword        string
+	clusterMode               string
+	enableParkedMessagesStats bool
 )
 
 func serveLandingPage() {
@@ -57,6 +58,7 @@ func readAndValidateConfig() {
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
 	flag.StringVar(&clusterMode, "cluster-mode", "cluster", "Cluster mode: `cluster` or `single`. In single mode, calls to cluster status endpoints are skipped")
 	flag.BoolVar(&insecureSkipVerify, "insecure-skip-verify", false, "Skip TLS certificatte verification for EventStore HTTP client")
+	flag.BoolVar(&enableParkedMessagesStats, "enable-parked-messages-stats", false, "Enable parked messages stats scraping")
 
 	flag.Parse()
 
@@ -69,13 +71,14 @@ func readAndValidateConfig() {
 	}
 
 	log.WithFields(logrus.Fields{
-		"eventStoreURL":      eventStoreURL,
-		"eventStoreUser":     eventStoreUser,
-		"port":               port,
-		"timeout":            timeout,
-		"verbose":            verbose,
-		"clusterMode":        clusterMode,
-		"insecureSkipVerify": insecureSkipVerify,
+		"eventStoreURL":             eventStoreURL,
+		"eventStoreUser":            eventStoreUser,
+		"port":                      port,
+		"timeout":                   timeout,
+		"verbose":                   verbose,
+		"clusterMode":               clusterMode,
+		"insecureSkipVerify":        insecureSkipVerify,
+		"enableParkedMessagesStats": enableParkedMessagesStats,
 	}).Infof("EventStore exporter configured")
 }
 


### PR DESCRIPTION
Added parked messages metrics support for persistent subscriptions.

Specifically I added the following: 
1. Parked messages count
2. Oldest parked message age (in seconds)
3. Made this functionality configurable. (`--enable-parked-messages-stats`)

Using the following parameter `--enable-parked-messages-stats` when running the project.

I get the following metrics:

![image](https://user-images.githubusercontent.com/56027298/93200469-b2a33300-f747-11ea-9679-8321381dc0eb.png)



The metrics can be displayed in the following format:

![image](https://user-images.githubusercontent.com/56027298/93199208-03199100-f746-11ea-9948-17cd6339b066.png)
