### PR TITLE
Return projection status as per #26

### DIFF
--- a/internal/client/projection_stats.go
+++ b/internal/client/projection_stats.go
@@ -12,6 +12,8 @@ type getProjectionStatsResult struct {
 type ProjectionStats struct {
 	Name                        string
 	Running                     bool
+	Stopped                     bool
+	Faulted                     bool
 	Progress                    float64
 	EventsProcessedAfterRestart int64
 }
@@ -40,6 +42,8 @@ func getProjectionStats(projectionsJson []byte) []ProjectionStats {
 		projections = append(projections, ProjectionStats{
 			Name:                        getString(jsonValue, "effectiveName"),
 			Running:                     getString(jsonValue, "status") == "Running",
+			Stopped:                     getString(jsonValue, "status") == "Stopped",
+			Faulted:                     getString(jsonValue, "status") == "Faulted",
 			Progress:                    getFloat(jsonValue, "progress") / 100.0, // scale to 0-1
 			EventsProcessedAfterRestart: getInt(jsonValue, "eventsProcessedAfterRestart"),
 		})


### PR DESCRIPTION
Added a new gauge `eventstore_projection_status` which provide a `Running`, `Stopped`, or `Faulted` status for each projection. I kept the `eventstore_projection_running` field as per the comment on #26 

Example:

```
# HELP eventstore_projection_running If 1, projection is in 'Running' state
# TYPE eventstore_projection_running gauge
eventstore_projection_running{projection="$by_category"} 1
eventstore_projection_running{projection="$by_correlation_id"} 1
eventstore_projection_running{projection="$by_event_type"} 1
eventstore_projection_running{projection="$stream_by_category"} 1
eventstore_projection_running{projection="$streams"} 1
eventstore_projection_running{projection="broken"} 0
# HELP eventstore_projection_status If 1, projection is in specified state
# TYPE eventstore_projection_status gauge
eventstore_projection_status{projection="$by_category",status="Faulted"} 0
eventstore_projection_status{projection="$by_category",status="Running"} 1
eventstore_projection_status{projection="$by_category",status="Stopped"} 0
eventstore_projection_status{projection="$by_correlation_id",status="Faulted"} 0
eventstore_projection_status{projection="$by_correlation_id",status="Running"} 1
eventstore_projection_status{projection="$by_correlation_id",status="Stopped"} 0
eventstore_projection_status{projection="$by_event_type",status="Faulted"} 0
eventstore_projection_status{projection="$by_event_type",status="Running"} 1
eventstore_projection_status{projection="$by_event_type",status="Stopped"} 0
eventstore_projection_status{projection="$stream_by_category",status="Faulted"} 0
eventstore_projection_status{projection="$stream_by_category",status="Running"} 1
eventstore_projection_status{projection="$stream_by_category",status="Stopped"} 0
eventstore_projection_status{projection="$streams",status="Faulted"} 0
eventstore_projection_status{projection="$streams",status="Running"} 1
eventstore_projection_status{projection="$streams",status="Stopped"} 0
eventstore_projection_status{projection="broken",status="Faulted"} 1
eventstore_projection_status{projection="broken",status="Running"} 0
eventstore_projection_status{projection="broken",status="Stopped"} 0
```