### PR TITLE
Upgrade Go to 1.26 and golangci-lint to v2.11.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0.2
+          version: v2.11.3
 
   test:
     strategy:
@@ -34,7 +34,7 @@ jobs:
     name: tests on ES ${{ matrix.esVersion }}
 
     runs-on: ubuntu-latest
-    container: golang:1.24-bookworm
+    container: golang:1.26-bookworm
 
     services:
       eventstore:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.24-alpine as build
+FROM golang:1.26-alpine AS build
 
 WORKDIR /go/src/github.com/marcinbudny/eventstore_exporter
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -o app
 
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run -d -p 9448:9448 \
 
 ### From source
 
-You need to have a Go 1.24+ environment configured.
+You need to have a Go 1.26+ environment configured.
 
 ```bash
 go install github.com/marcinbudny/eventstore_exporter@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/marcinbudny/eventstore_exporter
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/EventStore/EventStore-Client-Go/v4 v4.2.0

--- a/internal/client/subscription_stats.go
+++ b/internal/client/subscription_stats.go
@@ -101,7 +101,7 @@ func getParkedMessagesStats(ctx context.Context, grpc *esdb.Client, eventStreamI
 		oldestAgeInSec, _ = getOldestParkedMessageAgeInSeconds(ctx, grpc, eventStreamID, groupName, oldestMessagePosition)
 	}
 
-	numParked = int64(totalNumberOfParkedMessages)
+	numParked = int64(totalNumberOfParkedMessages) // nolint:gosec // -1 is a valid value for this metric in the exporter
 
 	return
 }

--- a/lint.sh
+++ b/lint.sh
@@ -1,1 +1,1 @@
-docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.52.1 golangci-lint run
+docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.11.3 golangci-lint run


### PR DESCRIPTION
This PR updates the Go version to 1.26 across the repository, including CI workflows, Dockerfile, and go.mod. It also upgrades golangci-lint to v2.11.3 and adds a gosec lint suppression for parked message stats.